### PR TITLE
 $pkg is unused

### DIFF
--- a/lib/AudioFile/Info/MP3/Tag.pm
+++ b/lib/AudioFile/Info/MP3/Tag.pm
@@ -51,7 +51,7 @@ sub DESTROY {
 sub AUTOLOAD {
   our $AUTOLOAD;
 
-  my ($pkg, $sub) = $AUTOLOAD =~ /(.+)::(\w+)/;
+  my ($sub) = $AUTOLOAD =~ /::(\w+)$/;
 
   die "Invalid attribute $sub" unless exists $data{$sub};
 


### PR DESCRIPTION
I was assigned this repo by the  [Pull Request Club](https://pullrequest.club/). Often these days the low hanging fruit is going to be fixing the deprecation warnings in the github actions.  No real chance of that with a daveorg repo :-(. Anyway I noticed an unused var  and (I quote)  ... "unused variables clutter code and make it harder to read".
